### PR TITLE
feat: add file com.adobe.granite.cors.impl.CORSPolicyImpl~wknd-app.cfg.json

### DIFF
--- a/backend/wknd-app/ui.config/src/main/content/jcr_root/apps/wknd-app/osgiconfig/config/com.adobe.granite.cors.impl.CORSPolicyImpl~wknd-app.cfg.json
+++ b/backend/wknd-app/ui.config/src/main/content/jcr_root/apps/wknd-app/osgiconfig/config/com.adobe.granite.cors.impl.CORSPolicyImpl~wknd-app.cfg.json
@@ -1,0 +1,31 @@
+{
+    "supportscredentials":true,
+    "exposedheaders":[
+        ""
+    ],
+    "supportedmethods":[
+        "GET",
+        "HEAD",
+        "POST",
+        "OPTIONS"
+    ],
+    "alloworigin":[
+        "https://external-hosted-app", "localhost:3000"
+    ],
+    "maxage:Integer":1800,
+    "alloworiginregexp":[
+        ".*"
+    ],
+    "allowedpaths":[
+        ".*"
+    ],
+    "supportedheaders":[
+        "Origin",
+        "Accept",
+        "X-Requested-With",
+        "Content-Type",
+        "Access-Control-Request-Method",
+        "Access-Control-Request-Headers",
+        "authorization"
+    ]
+}


### PR DESCRIPTION
**EN**: The key configuration elements are:

- alloworigin specifies which hosts are allowed to retrieve content from AEM.
    - localhost:3000 is added to support the SPA running locally
    -  https://external-hosted-app acts as a placeholder to be replaced with the domain that Remote SPA is hosted on.

          
- allowedpaths specify which paths in AEM are covered by this CORS configuration. The default allows access to all content in AEM, however this can be scoped to only the specific paths the SPA can access, for example: /content/wknd-app.



**PT-BR**: Os principais elementos de configuração são:

- alloworigin especifica quais hosts têm permissão para recuperar conteúdo do AEM.
    - localhost:3000 é adicionado para oferecer suporte ao SPA executado localmente
    - https://external-hosted-app atua como um espaço reservado a ser substituído pelo domínio em que o SPA Remoto está hospedado.
    
- allowedpaths especifica quais caminhos no AEM são cobertos por esta configuração do CORS. O padrão permite o acesso a todo o conteúdo no AEM, no entanto, ele pode ser controlado apenas para os caminhos específicos que o SPA pode acessar, por exemplo: /content/wknd-app.

Reference:


- [Cross-Origin Resource Sharing Security Policies](https://experienceleague.adobe.com/en/docs/experience-manager-learn/getting-started-with-aem-headless/spa-editor/remote-spa/aem-configure#cross-origin-resource-sharing-security-policies)

- [OSGi](https://experienceleague.adobe.com/en/docs/experience-manager-learn/cloud-service/underlying-technology/introduction-osgi)