### PR TITLE
Set AEM Page as Remote SPA Page Template

### DIFF
--- a/backend/wknd-app/ui.content/src/main/content/jcr_root/content/wknd-app/us/en/home/.content.xml
+++ b/backend/wknd-app/ui.content/src/main/content/jcr_root/content/wknd-app/us/en/home/.content.xml
@@ -4,10 +4,10 @@
     <jcr:content
         cq:lastModified="{Date}2018-10-04T09:50:29.650+02:00"
         cq:lastModifiedBy="admin"
-        cq:template="/conf/wknd-app/settings/wcm/templates/spa-page-template"
+        cq:template="/conf/wknd-app/settings/wcm/templates/spa-remote-page"
         jcr:primaryType="cq:PageContent"
         jcr:title="WKND App Home Page"
-        sling:resourceType="wknd-app/components/page">
+        sling:resourceType="wknd-app/components/remotepage">
         <root
             jcr:primaryType="nt:unstructured"
             sling:resourceType="wcm/foundation/components/responsivegrid">


### PR DESCRIPTION
**EN**:  These changes allow this page, which acts are the SPA’s root in AEM, to load the Remote SPA in SPA Editor.

**PT-BR**: Essas alterações permitem que esta página, que atua como a raiz do SPA no AEM, carregue o SPA remoto no Editor SPA.

**Reference**

 [Set AEM Page as Remote SPA Page Template](https://experienceleague.adobe.com/en/docs/experience-manager-learn/getting-started-with-aem-headless/spa-editor/remote-spa/aem-configure#set-aem-page-as-remote-spa-page-template)